### PR TITLE
Use stable mongodb dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,8 @@
         "incenteev/composer-parameter-handler": "^2.0",
         "friendsofsymfony/rest-bundle": "^1.7",
         "jms/serializer-bundle": "^1.1",
-        "doctrine/mongodb": "dev-master",
-        "doctrine/mongodb-odm": "dev-master",
-        "doctrine/mongodb-odm-bundle": "dev-master",
-        "mongodb/mongodb":"@beta",
-        "alcaeus/mongo-php-adapter": "dev-composer-provide",
+        "doctrine/mongodb-odm-bundle": "^3.2.1",
+        "alcaeus/mongo-php-adapter": "^1.0.6",
         "ramsey/uuid": "^3.2",
         "nelmio/api-doc-bundle": "^2.11",
         "nelmio/cors-bundle": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e6af6a633b1b3e32dea09a45e0ca3f2a",
-    "content-hash": "3b88a4f95d4533f8a61362796e9cbfaa",
+    "hash": "d3e753ac6c4e8aef1be205be32ac3556",
+    "content-hash": "a3723ca295aea4a62678d9374d029bd1",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
-            "version": "dev-composer-provide",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/alcaeus/mongo-php-adapter.git",
-                "reference": "698d3012c306af299491aa166dc9aa29a4bce5b8"
+                "reference": "6ebf8087be2e4c6eb13fcd74f5dc549bea84a7de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/alcaeus/mongo-php-adapter/zipball/698d3012c306af299491aa166dc9aa29a4bce5b8",
-                "reference": "698d3012c306af299491aa166dc9aa29a4bce5b8",
+                "url": "https://api.github.com/repos/alcaeus/mongo-php-adapter/zipball/6ebf8087be2e4c6eb13fcd74f5dc549bea84a7de",
+                "reference": "6ebf8087be2e4c6eb13fcd74f5dc549bea84a7de",
                 "shasum": ""
             },
             "require": {
                 "ext-hash": "*",
-                "mongodb/mongodb": "^1.0.0",
+                "mongodb/mongodb": "^1.0.1",
                 "php": "^5.5 || ^7.0"
             },
             "provide": {
-                "ext-mongo": "1.6.12"
+                "ext-mongo": "1.6.13"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8 || ^5.0"
@@ -68,7 +68,7 @@
                 "database",
                 "mongodb"
             ],
-            "time": "2016-02-25 06:48:46"
+            "time": "2016-10-07 05:18:57"
         },
         {
             "name": "doctrine/annotations",
@@ -762,34 +762,35 @@
         },
         {
             "name": "doctrine/mongodb",
-            "version": "dev-master",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/mongodb.git",
-                "reference": "b4eb8683d66d44de4e9e4e974149bdce327dc818"
+                "reference": "293ad1ee54b507e269d6a1309dbeb8c00621b00e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/mongodb/zipball/58d52b279ca63571361e5ea928e6a8dbc3fafda1",
-                "reference": "b4eb8683d66d44de4e9e4e974149bdce327dc818",
+                "url": "https://api.github.com/repos/doctrine/mongodb/zipball/293ad1ee54b507e269d6a1309dbeb8c00621b00e",
+                "reference": "293ad1ee54b507e269d6a1309dbeb8c00621b00e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "^2.2",
                 "ext-mongo": "^1.5",
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "jmikola/geojson": "^1.0",
                 "phpunit/phpunit": "~4.8|~5.0"
             },
             "suggest": {
+                "alcaeus/mongo-php-adapter": "Allows usage of PHP 7",
                 "jmikola/geojson": "Support GeoJSON geometry objects in 2dsphere queries"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
@@ -834,20 +835,20 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2016-03-19 18:45:48"
+            "time": "2016-11-22 19:01:59"
         },
         {
             "name": "doctrine/mongodb-odm",
-            "version": "dev-master",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/mongodb-odm.git",
-                "reference": "5aa45fceb8ec2f08531f8372f4dd021f2b3113cc"
+                "reference": "e839648ef7649757aae3b9818236a6fa47c016cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/c1e9777d1e083d819a354553522903b3b83a6f39",
-                "reference": "5aa45fceb8ec2f08531f8372f4dd021f2b3113cc",
+                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/e839648ef7649757aae3b9818236a6fa47c016cd",
+                "reference": "e839648ef7649757aae3b9818236a6fa47c016cd",
                 "shasum": ""
             },
             "require": {
@@ -858,7 +859,7 @@
                 "doctrine/inflector": "~1.0",
                 "doctrine/instantiator": "~1.0.1",
                 "doctrine/mongodb": "~1.3",
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "symfony/console": "~2.3|~3.0"
             },
             "require-dev": {
@@ -866,12 +867,13 @@
                 "symfony/yaml": "~2.3|~3.0"
             },
             "suggest": {
+                "alcaeus/mongo-php-adapter": "Allows usage of PHP 7",
                 "symfony/yaml": "Enables the YAML metadata mapping driver"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -917,25 +919,25 @@
                 "odm",
                 "persistence"
             ],
-            "time": "2016-03-21 19:27:35"
+            "time": "2016-10-07 09:18:05"
         },
         {
             "name": "doctrine/mongodb-odm-bundle",
-            "version": "dev-master",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineMongoDBBundle.git",
-                "reference": "f4d043d533a530841ebbb6efd5889cc20d5af2ef"
+                "reference": "9ad10aa1c64fe140537ebb1306fe0f4d2357f6fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineMongoDBBundle/zipball/2ea4124bd30b29153242fdefdc59f6d72e06426c",
-                "reference": "f4d043d533a530841ebbb6efd5889cc20d5af2ef",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMongoDBBundle/zipball/9ad10aa1c64fe140537ebb1306fe0f4d2357f6fd",
+                "reference": "9ad10aa1c64fe140537ebb1306fe0f4d2357f6fd",
                 "shasum": ""
             },
             "require": {
-                "doctrine/mongodb-odm": "^1.0",
-                "php": "^5.5 || ^7.0",
+                "doctrine/mongodb-odm": "^1.1",
+                "php": "^5.6 || ^7.0",
                 "psr/log": "^1.0",
                 "symfony/config": "^2.7 || ^3.0",
                 "symfony/console": "^2.7 || ^3.0",
@@ -946,6 +948,7 @@
             },
             "require-dev": {
                 "doctrine/data-fixtures": "@dev",
+                "phpunit/phpunit": "^5.6",
                 "symfony/form": "^2.7 || ^3.0",
                 "symfony/phpunit-bridge": "^2.7 || ^3.0",
                 "symfony/yaml": "^2.7 || ^3.0"
@@ -989,7 +992,7 @@
                 "persistence",
                 "symfony"
             ],
-            "time": "2016-03-19 20:12:36"
+            "time": "2016-12-08 07:05:40"
         },
         {
             "name": "doctrine/orm",
@@ -1537,16 +1540,16 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.0.1",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "6093d68c06bebcc5361b9e49178725efd9182ed4"
+                "reference": "302de20d8302183e1c70b335d81798cec5bcebd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/6093d68c06bebcc5361b9e49178725efd9182ed4",
-                "reference": "6093d68c06bebcc5361b9e49178725efd9182ed4",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/302de20d8302183e1c70b335d81798cec5bcebd4",
+                "reference": "302de20d8302183e1c70b335d81798cec5bcebd4",
                 "shasum": ""
             },
             "require": {
@@ -1554,11 +1557,6 @@
                 "php": ">=5.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "MongoDB\\": "src/"
@@ -1593,7 +1591,7 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2016-03-04 20:27:01"
+            "time": "2016-12-05 20:02:14"
         },
         {
             "name": "monolog/monolog",
@@ -3647,13 +3645,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "doctrine/mongodb": 20,
-        "doctrine/mongodb-odm": 20,
-        "doctrine/mongodb-odm-bundle": 20,
-        "mongodb/mongodb": 10,
-        "alcaeus/mongo-php-adapter": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
The doctrine MongoDB packages, the MongoDB library as well as the MongoDB adapter are available as stable releases. This PR uses these stable releases instead of relying on branches that may bring incompatible changes.